### PR TITLE
Build_lut updates for Isofit 3

### DIFF
--- a/aggregated_combined_data.py
+++ b/aggregated_combined_data.py
@@ -48,13 +48,15 @@ def main():
     parser.add_argument('-config_file', type=str, default='templates/isofit_template.json')
     parser.add_argument('-keys', type=str, default=['rhoatm', 'sphalb', 'transm_down_dir', 'transm_down_dif', 'transm_up_dir', 'transm_up_dif' ], nargs='+')
     parser.add_argument('-munge_dir', type=str, default='munged')
+    parser.add_argument('-figs_dir', type=str, default=None)
 
     args = parser.parse_args()
 
     np.random.seed(13)
 
+    outdict_sixs, outdict_modtran = {}, {}
+    munge_file = os.path.join(args.munge_dir, 'combined_data.npz')
     for key_ind, key in enumerate(args.keys):
-        munge_file = os.path.join(args.munge_dir, key + '.npz')
 
         if os.path.isfile(munge_file) is False:
             config = configs.create_new_config(args.config_file)
@@ -84,174 +86,60 @@ def main():
             isofit_sixs = SixSRT(**params)
 
 
-            point_dims = list(isofit_modtran.lut_grid.keys())
-            rtm_key = 'transm_down_dir'
-            for sp,mp,std_dir,mtd_dir, std_dif, mtd_dif, stu_dir, mtu_dir, stu_dif, mtu_dif, s_r, m_r  in zip(isofit_sixs.points, isofit_modtran.points, 
-                    isofit_sixs.lut['transm_down_dir'], isofit_modtran.lut['transm_down_dir'],
-                    isofit_sixs.lut['transm_down_dif'], isofit_modtran.lut['transm_down_dif'],
-                    isofit_sixs.lut['transm_up_dir'], isofit_modtran.lut['transm_up_dir'],
-                    isofit_sixs.lut['transm_up_dif'], isofit_modtran.lut['transm_up_dif'],
-                    isofit_sixs.lut['rhoatm'], isofit_modtran.lut['rhoatm'],
-                    ):
-                name='_'.join([f'{point_dims[x]}_{sp[x]}' for x in range(len(sp))])
-                plt.plot(isofit_sixs.wl, std_dir, color='black', label='t_down_dir')
-                plt.plot(isofit_sixs.wl, std_dif, color='grey', label='t_down_dif')
-                plt.plot(isofit_sixs.wl, stu_dir, color='red', label='t_up_dir')
-                plt.plot(isofit_sixs.wl, stu_dif, color='purple', label='t_up_dif')
-                plt.plot(isofit_sixs.wl, s_r, color='green', label='rhoatm')
-                
-                name2='_'.join([f'{point_dims[x]}_{mp[x]}' for x in range(len(mp))])
-                plt.plot(isofit_modtran.wl, mtd_dir, color='black', ls = '--')
-                plt.plot(isofit_modtran.wl, mtd_dif, color='grey', ls = '--')
-                plt.plot(isofit_modtran.wl, mtu_dir, color='red', ls = '--')
-                plt.plot(isofit_modtran.wl, mtu_dif, color='purple', ls = '--')
-                plt.plot(isofit_modtran.wl, m_r, color='green', ls = '--')
+            if args.figs_dir is not None:
+                point_dims = list(isofit_modtran.lut_grid.keys())
+                point_dims_s = list(isofit_sixs.lut_grid.keys())
+                rtm_key = 'transm_down_dir'
+                for _ind in range(isofit_sixs.lut['rhoatm'].shape[0]):
 
-                plt.legend(fontsize=4, loc='lower right')
-                
-                plt.title(f'S: {name}\n M: {name2}',fontsize=6)
+                    sp = isofit_sixs.points[_ind,:]
+                    mp = isofit_modtran.points[_ind,:]
 
-                plt.savefig(f'figs/{name.replace("\n","_")}.png',dpi=100)
-                plt.clf()
+                    std_dir = isofit_sixs.lut['transm_down_dir'][_ind,:]
+                    mtd_dir = isofit_modtran.lut['transm_down_dir'][_ind,:]
+                    std_dif = isofit_sixs.lut['transm_down_dif'][_ind,:]
+                    mtd_dif = isofit_modtran.lut['transm_down_dif'][_ind,:]
+                    stu_dir = isofit_sixs.lut['transm_up_dir'][_ind,:]
+                    mtu_dir = isofit_modtran.lut['transm_up_dir'][_ind,:]
+                    stu_dif = isofit_sixs.lut['transm_up_dif'][_ind,:]
+                    mtu_dif = isofit_modtran.lut['transm_up_dif'][_ind,:]
+                    s_r = isofit_sixs.lut['rhoatm'][_ind,:]
+                    m_r = isofit_modtran.lut['rhoatm'][_ind,:]
 
-            exit()
-            #import ipdb; ipdb.set_trace()
-            #sixs_results = 1
-            #modtran_results = 1
+                    name='_'.join([f'{point_dims_s[x]}_{sp[x]}' for x in range(len(sp))])
+                    plt.plot(isofit_sixs.wl, std_dir, color='black', label='t_down_dir')
+                    plt.plot(isofit_sixs.wl, std_dif, color='grey', label='t_down_dif')
+                    plt.plot(isofit_sixs.wl, stu_dir, color='red', label='t_up_dir')
+                    plt.plot(isofit_sixs.wl, stu_dif, color='purple', label='t_up_dif')
+                    plt.plot(isofit_sixs.wl, s_r, color='green', label='rhoatm')
+                    
+                    name2='_'.join([f'{point_dims[x]}_{mp[x]}' for x in range(len(mp))])
+                    plt.plot(isofit_modtran.wl, mtd_dir, color='black', ls = '--')
+                    plt.plot(isofit_modtran.wl, mtd_dif, color='grey', ls = '--')
+                    plt.plot(isofit_modtran.wl, mtu_dir, color='red', ls = '--')
+                    plt.plot(isofit_modtran.wl, mtu_dif, color='purple', ls = '--')
+                    plt.plot(isofit_modtran.wl, m_r, color='green', ls = '--')
 
+                    plt.legend(fontsize=4, loc='lower right')
+                    
+                    plt.title(f'S: {name}\n M: {name2}',fontsize=6)
 
-            sixs_results = get_obj_res(isofit_sixs, key, resample=False)
-            modtran_results = get_obj_res(isofit_modtran, key)
+                    plt.savefig(f'{args.figs_dir}/{name.replace("\n","_")}.png',dpi=100)
+                    plt.clf()
 
-            if os.path.isdir(os.path.dirname(munge_file) is False):
-                os.mkdir(os.path.dirname(munge_file))
+            point_names = isofit_sixs.lut.point.to_index().names
+            bad_points = np.zeros(isofit_sixs.lut[key].shape[0],dtype=bool)
+            if 'surface_elevation_km' in point_names and 'observer_altitude_km' in point_names:
+                bad_points = isofit_sixs.lut[key][:, point_names.index('surface_elevation_km')]  >= isofit_sixs.lut[key][:, point_names.index('observer_altitude_km')] -2
+                good_points = np.logical_not(bad_points)
+            
+            outdict_sixs[key] = np.array(isofit_sixs.lut[key])[good_points,:]
+            outdict_modtran[key] = np.array(isofit_modtran.lut[key])[good_points,:]
 
-            for fn in isofit_modtran.files:
-                mod_output = isofit_modtran.load_rt(fn)
-                sol_irr = mod_output['sol']
-                if np.all(np.isfinite(sol_irr)):
-                    break
+    np.savez(munge_file, modtran_results=outdict_modtran, 
+                         sixs_results=outdict_sixs, 
+                         sol_irr=isofit_sixs.lut.solar_irr)
 
-            np.savez(munge_file, modtran_results=modtran_results, sixs_results=sixs_results, sol_irr=sol_irr)
-
-    modtran_results = None
-    sixs_results = None
-    for key_ind, key in enumerate(args.keys):
-        munge_file = os.path.join(args.munge_dir, key + '.npz')
-
-        npzf = np.load(munge_file)
-
-        dim1 = int(np.product(np.array(npzf['modtran_results'].shape)[:-1]))
-        dim2 = npzf['modtran_results'].shape[-1]
-        if modtran_results is None:
-            modtran_results = np.zeros((dim1,dim2*len(args.keys)))
-        modtran_results[:,dim2*key_ind:dim2*(key_ind+1)] = npzf['modtran_results']
-
-        dim1 = int(np.product(np.array(npzf['sixs_results'].shape)[:-1]))
-        dim2 = npzf['sixs_results'].shape[-1]
-        if sixs_results is None:
-            sixs_results = np.zeros((dim1,dim2*len(args.keys)))
-        sixs_results[:,dim2*key_ind:dim2*(key_ind+1)] = npzf['sixs_results']
-
-        sol_irr = npzf['sol_irr']
-
-
-    config = configs.create_new_config(args.config_file)
-    isofit_modtran = ModtranRT(config.forward_model.radiative_transfer.radiative_transfer_engines[0],
-                               config, build_lut=False)
-    isofit_sixs = SixSRT(config.forward_model.radiative_transfer.radiative_transfer_engines[1],
-                        config, build_lut=False)
-    sixs_names = isofit_sixs.lut_names
-    modtran_names = isofit_modtran.lut_names
-
-    #if 'elev' in sixs_names:
-    #    sixs_names[sixs_names.index('elev')] = 'GNDALT'
-    #if 'viewzen' in sixs_names:
-    #    sixs_names[sixs_names.index('viewzen')] = 'OBSZEN'
-    #if 'viewaz' in sixs_names:
-    #    sixs_names[sixs_names.index('viewaz')] = 'TRUEAZ'
-    #if 'alt' in sixs_names:
-    #    sixs_names[sixs_names.index('alt')] = 'H1ALT'
-    #if 'AOT550' in sixs_names:
-    #    sixs_names[sixs_names.index('AOT550')] = 'AERFRAC_2'
-
-    reorder_sixs = [sixs_names.index(x) for x in modtran_names]
-
-    points = isofit_modtran.points.copy()
-    points_sixs = isofit_sixs.points.copy()[:,reorder_sixs]
-
-    #if 'OBSZEN' in modtran_names:
-    #    print('adjusting')
-    #    points_sixs[:, modtran_names.index('OBSZEN')] = 180 - points_sixs[:, modtran_names.index('OBSZEN')]
-
-
-    ind = np.lexsort(tuple([points[:,x] for x in range(points.shape[-1])]))
-    points = points[ind,:]
-    modtran_results = modtran_results[ind,:]
-
-    ind_sixs = np.lexsort(tuple([points_sixs[:,x] for x in range(points_sixs.shape[-1])]))
-    points_sixs = points_sixs[ind_sixs,:]
-    sixs_results = sixs_results[ind_sixs,:]
-
-
-    good_data = np.all(np.isnan(modtran_results) == False,axis=1)
-    good_data[np.any(np.isnan(sixs_results),axis=1)] = False
-
-    modtran_results = modtran_results[good_data,:]
-    sixs_results = sixs_results[good_data,:]
-    points = points[good_data,...]
-    points_sixs = points_sixs[good_data,...]
-
-    print(sixs_results.shape)
-    print(modtran_results.shape)
-
-    tmp = isofit_sixs.load_rt(isofit_sixs.files[0])
-
-    np.savez(os.path.join(args.munge_dir, 'combined_training_data.npz'), sixs_results=sixs_results, modtran_results=modtran_results,
-             points=points, points_sixs=points_sixs, keys=args.keys, point_names=modtran_names, modtran_wavelengths=isofit_modtran.wl,
-             sixs_wavelengths=isofit_sixs.grid,
-             sol_irr=sol_irr)
-
-
-@ray.remote
-def read_data_piece(ind, maxind, point, fn, key, resample, obj):
-    if ind % 100 == 0:
-        print('{}: {}/{}'.format(key, ind, maxind))
-    try:
-        if resample is False:
-            mod_output = obj.load_rt(fn, resample=False)
-        else:
-            mod_output = obj.load_rt(fn)
-        res = mod_output[key]
-    except:
-        res = None
-    return ind, res
-
-
-
-def get_obj_res(obj, key, resample=True):
-
-    # We don't want the VectorInterpolator, but rather the raw inputs
-    ray.init(_temp_dir='/local/ray/brodrick/')
-    if hasattr(obj,'sixs_ngrid_init'):
-        results = np.zeros((obj.points.shape[0],obj.sixs_ngrid_init), dtype=float)
-    else:
-        results = np.zeros((obj.points.shape[0],obj.n_chan), dtype=float)
-    objid = ray.put(obj)
-    jobs = []
-    for ind, (point, fn) in enumerate(zip(obj.points, obj.files)):
-        jobs.append(read_data_piece.remote(ind, results.shape[0], point, fn, key, resample, objid))
-    rreturn = [ray.get(jid) for jid in jobs]
-    for ind, res in rreturn:
-        if res is not None:
-            try:
-                results[ind,:] = res
-            except:
-                results[ind,:] = np.nan
-        else:
-            results[ind,:] = np.nan
-    ray.shutdown()
-    return results
 
 
 if __name__ == '__main__':

--- a/build_luts.py
+++ b/build_luts.py
@@ -132,7 +132,7 @@ def main():
                 'elevation_km_lut': [0, 1.5, 4.5, 6],
                 'h2o_lut': list(np.sort(
                     np.round(np.linspace(0.1, 5, num=5), 3).tolist()
-                )),
+                )) + [0.7125, 1.9375, 3.162, 4.3875],
                 'aerfrac_2_lut': list(np.sort(
                     np.round(np.linspace(0.01, 1, num=5), 3).tolist()
                 ))

--- a/build_luts.py
+++ b/build_luts.py
@@ -18,34 +18,64 @@
 
 
 import numpy as np
-from isofit.utils.apply_oe import write_modtran_template, SerialEncoder
 import os
 import json
-from isofit.radiative_transfer.modtran import ModtranRT
-from isofit.radiative_transfer.six_s import SixSRT
-from isofit.configs import configs, Config
 import datetime
 import ray
 import argparse
-from isofit.core.sunposition import sunpos
+from types import SimpleNamespace
+import logging
+
+from scipy.stats import qmc
+
+from isofit.utils.template_construction import (
+    write_modtran_template,
+    SerialEncoder,
+    get_lut_subset,
+)
+from isofit.data import env
+from isofit.radiative_transfer.radiative_transfer import confPriority 
+from isofit.radiative_transfer.engines.modtran import ModtranRT
+from isofit.radiative_transfer.engines.six_s import SixSRT
+from isofit.configs import configs, Config
 
 
 def main():
-
     # Parse arguments
     parser = argparse.ArgumentParser(description="built luts for emulation.")
-    parser.add_argument('-ip_head', type=str)
-    parser.add_argument('-redis_password', type=str)
+    parser.add_argument('-dir', default='', help='Working Dir')
     parser.add_argument('-n_cores', type=int, default=1)
     parser.add_argument('-train', type=int, default=1, choices=[0,1])
     parser.add_argument('-cleanup', type=int, default=0, choices=[0,1])
-
+    parser.add_argument('-ip_head', type=str)
+    parser.add_argument('-redis_password', type=str)
+    parser.add_argument(
+        '--configure_and_exit', 
+        default=False, 
+        action=argparse.BooleanOptionalAction
+    )
+    parser.add_argument(
+        '-sixs_path',
+        default=None,
+        help='SIXS Installation DIR'
+    )
+    parser.add_argument(
+        '-modtran_path',
+        default=None,
+        help='MODTRAN Installation DIR'
+    )
     args = parser.parse_args()
 
-    args.train = args.train == 1
+    args.training = args.train == 1
     args.cleanup = args.cleanup == 1
 
+
     dayofyear = 200
+
+    paths = Paths(
+        args,
+        args.training
+    )
 
     if args.train:
         to_solar_zenith_lut = [0, 12.5, 25, 37.5, 50]
@@ -54,10 +84,22 @@ def main():
         to_sensor_zenith_lut = [140, 160, 180]
         altitude_km_lut = [2, 4, 7, 10, 15, 25]
         elevation_km_lut = [0, 0.75, 1.5, 2.25, 4.5]
-        h2o_lut_grid = np.round(np.linspace(0.1,5,num=5),3).tolist() + [0.6125]
+        h2o_lut_grid = (
+            np.round(np.linspace(0.1, 5, num=5), 3).tolist() + [0.6125]
+        )
         h2o_lut_grid.sort()
-        aerfrac_2_lut_grid = np.round(np.linspace(0.01,1,num=5),3).tolist() + [0.5]
+        aerfrac_2_lut_grid = (
+            np.round(np.linspace(0.01, 1, num=5), 3).tolist() + [0.5]
+        )
         aerfrac_2_lut_grid.sort()
+        relative_azimuth_lut = np.abs(
+            np.array(to_solar_azimuth_lut) 
+            - np.array(to_sensor_azimuth_lut)
+        )
+        relative_azimuth_lut = np.minimum(
+            relative_azimuth_lut, 
+            360 - relative_azimuth_lut
+        )
 
     else:
         # HOLDOUT SET
@@ -67,19 +109,26 @@ def main():
         to_sensor_zenith_lut = [145, 155, 165, 175]
         altitude_km_lut = [3, 5.5, 8.5, 12.5, 17.5]
         elevation_km_lut = [0.325, 1.025, 1.875, 2.575, 4.2]
-        h2o_lut_grid = np.round(np.linspace(0.5,4.5,num=4),3)
-        aerfrac_2_lut_grid = np.round(np.linspace(0.125,0.9,num=4),3)
+        h2o_lut_grid = np.round(np.linspace(0.5, 4.5, num=4), 3)
+        aerfrac_2_lut_grid = np.round(np.linspace(0.125, 0.9, num=4), 3)
+        relative_azimuth_lut = np.abs(
+            np.array(to_solar_azimuth_lut) 
+            - np.array(to_sensor_azimuth_lut)
+        )
+        relative_azimuth_lut = np.minimum(
+            relative_azimuth_lut, 
+            360 - relative_azimuth_lut
+        )
 
-
-
-    n_lut_build = np.product([len(to_solar_zenith_lut),
-                                                     len(to_solar_azimuth_lut),
-                                                     len(to_sensor_zenith_lut),
-                                                     len(to_sensor_azimuth_lut),
-                                                     len(altitude_km_lut),
-                                                     len(elevation_km_lut),
-                                                     len(h2o_lut_grid),
-                                                     len(aerfrac_2_lut_grid)])
+    n_lut_build = np.prod([
+        len(to_solar_zenith_lut),
+        len(to_sensor_zenith_lut),
+        len(relative_azimuth_lut),
+        len(altitude_km_lut),
+        len(elevation_km_lut),
+        len(h2o_lut_grid),
+        len(aerfrac_2_lut_grid)
+    ])
 
     print('Num LUTs to build: {}'.format(n_lut_build))
     print('Expected MODTRAN runtime: {} hrs'.format(n_lut_build*1.5))
@@ -92,68 +141,133 @@ def main():
     wl_file_contents[:,0] = np.arange(len(wl),dtype=int)
     wl_file_contents[:,1] = wl
     wl_file_contents[:,2] = 0.0005
-    np.savetxt('support/hifidelity_wavelengths.txt',wl_file_contents,fmt='%.5f')
 
-    # Initialize ray for parallel execution
-    rayargs = {'address': args.ip_head,
-               'redis_password': args.redis_password,
-               'local_mode': args.n_cores == 1}
-
-    if args.n_cores < 40:
-        rayargs['num_cpus'] = args.n_cores
-    ray.init(**rayargs)
-    print(ray.cluster_resources())
-
-    template_dir = 'templates'
-    if os.path.isdir(template_dir) is False:
-        os.mkdir(template_dir)
-
-    modtran_template_file = os.path.join(template_dir,'modtran_template.json')
-
-    if args.training:
-        isofit_config_file = os.path.join(template_dir,'isofit_template_v2.json')
-    else:
-        isofit_config_file = os.path.join(template_dir,'isofit_template_holdout.json')
-
-    write_modtran_template(atmosphere_type='ATM_MIDLAT_SUMMER', fid=os.path.splitext(modtran_template_file)[0],
-                           altitude_km=altitude_km_lut[0],
-                          dayofyear=dayofyear, latitude=to_solar_azimuth_lut[0], longitude=to_solar_zenith_lut[0],
-                          to_sensor_azimuth=to_sensor_azimuth_lut[0], to_sensor_zenith=to_sensor_zenith_lut[0],
-                          gmtime=0, elevation_km=elevation_km_lut[0], output_file=modtran_template_file)
-
+    np.savetxt(
+        paths.wavelength_file, 
+        wl_file_contents,fmt='%.5f'
+    )
+    write_modtran_template(
+        atmosphere_type='ATM_MIDLAT_SUMMER', 
+        fid=os.path.splitext(paths.modtran_template_file)[0],
+        altitude_km=altitude_km_lut[0],
+        dayofyear=dayofyear, 
+        to_sensor_azimuth=to_sensor_azimuth_lut[0],
+        to_sensor_zenith=to_sensor_zenith_lut[0],
+        to_sun_zenith=to_solar_azimuth_lut[0],
+        relative_azimuth=relative_azimuth_lut[0],
+        gmtime=0, 
+        elevation_km=elevation_km_lut[0], 
+        output_file=paths.modtran_template_file,
+        ihaze_type="AER_NONE",
+    )
 
     # Make sure H2O grid is fully valid
-    with open(modtran_template_file, 'r') as f:
+    with open(paths.modtran_template_file, 'r') as f:
         modtran_config = json.load(f)
+
     modtran_config['MODTRAN'][0]['MODTRANINPUT']['GEOMETRY']['IPARM'] = 12
     modtran_config['MODTRAN'][0]['MODTRANINPUT']['ATMOSPHERE']['H2OOPT'] = '+'
     modtran_config['MODTRAN'][0]['MODTRANINPUT']['AEROSOLS']['VIS'] = 100
-    with open(modtran_template_file, 'w') as fout:
-        fout.write(json.dumps(modtran_config, cls=SerialEncoder, indent=4, sort_keys=True))
+    with open(paths.modtran_template_file, 'w') as fout:
+        fout.write(json.dumps(
+            modtran_config, 
+            cls=SerialEncoder, 
+            indent=4, 
+            sort_keys=True
+        ))
 
-    paths = Paths(os.path.join('.',os.path.basename(modtran_template_file)), args.training)
+    configure_and_exit = args.configure_and_exit
+    build_main_config(
+        paths, 
+        h2o_lut_grid, 
+        elevation_km_lut, 
+        altitude_km_lut, 
+        to_sensor_zenith_lut, 
+        to_solar_zenith_lut, 
+        to_sensor_azimuth_lut, 
+        to_solar_azimuth_lut, 
+        relative_azimuth_lut,
+        aerfrac_2_lut_grid, 
+        paths.isofit_config_file, 
+        configure_and_exit=configure_and_exit,
+        ip_head=args.ip_head,
+        redis_password=args.redis_password,
+        n_cores=args.n_cores
+    )
 
+    config = configs.create_new_config(paths.isofit_config_file)
 
-    build_main_config(paths, isofit_config_file, to_solar_azimuth_lut, to_solar_zenith_lut, 
-                      aerfrac_2_lut_grid, h2o_lut_grid, elevation_km_lut, altitude_km_lut, to_sensor_azimuth_lut,
-                      to_sensor_zenith_lut, n_cores=args.n_cores)
+    if args.configure_and_exit:
+        ray.init(
+            num_cpus=args.n_cores,
+            _temp_dir=config.implementation.ray_temp_dir ,
+            include_dashboard=False,
+            local_mode=args.n_cores == 1,
+        )
 
-    config = configs.create_new_config(isofit_config_file)
+    else:
+        # Initialize ray for parallel execution
+        rayargs = {
+            'address': config.implementation.ip_head,
+            '_redis_password': config.implementation.redis_password,
+            'local_mode': args.n_cores == 1
+        }
 
+        if args.n_cores < 40:
+            rayargs['num_cpus'] = args.n_cores
 
-    isofit_modtran = ModtranRT(config.forward_model.radiative_transfer.radiative_transfer_engines[0],
-                               config)
+        ray.init(**rayargs)
+        print(ray.cluster_resources())
 
-    isofit_sixs = SixSRT(config.forward_model.radiative_transfer.radiative_transfer_engines[1],
-                         config)
+    # Inits of engines based on radiative_transfer.py
+    rt_config = config.forward_model.radiative_transfer
+    instrument_config = config.forward_model.instrument
+
+    lut_grid = rt_config.lut_grid
+
+    _keys = [
+        "interpolator_style",
+        "overwrite_interpolator",
+        "lut_grid",
+        "lut_path",
+        "wavelength_file",
+    ]
+
+    modtran_engine_config = rt_config.radiative_transfer_engines[0]
+    params = {
+        key: confPriority(key, [
+            modtran_engine_config, instrument_config, rt_config
+        ]) 
+        for key in _keys
+    }
+    params["engine_config"] = modtran_engine_config 
+    params['lut_grid'] = {
+        key: params['lut_grid'][key] for key in
+        modtran_engine_config.lut_names.keys()
+    }
+    isofit_modtran = ModtranRT(**params)
+
+    sixs_engine_config = rt_config.radiative_transfer_engines[1]
+    params = {
+        key: confPriority(key, [
+            sixs_engine_config, instrument_config, rt_config
+        ])
+        for key in _keys
+    }
+    params["engine_config"] = sixs_engine_config 
+    params['lut_grid'] = {
+        key: params['lut_grid'][key] for key in
+        sixs_engine_config.lut_names.keys()
+    }
+    # params['modtran_emulation'] = True
+    isofit_sixs = SixSRT(**params)
 
     # cleanup
     if args.cleanup:
         for to_rm in ['*r_k', '*t_k', '*tp7', '*wrn', '*psc', '*plt', '*7sc', '*acd']:
-            cmd = 'find {os.path.join(paths.lut_modtran_directory)} -name "{to_rm}"')
+            cmd = 'find {os.path.join(paths.lut_modtran_directory)} -name "{to_rm}"'
             print(cmd)
             os.system(cmd)
-
 
 
 def build_modtran_configs(isofit_config: Config, template_file: str):
@@ -163,60 +277,145 @@ def build_modtran_configs(isofit_config: Config, template_file: str):
 
 class Paths():
 
-    def __init__(self, modtran_tpl, training=True):
-        self.aerosol_tpl_path =  '../support/aerosol_template.json'
-        self.aerosol_model_path =  '../support/aerosol_model.txt'
-        self.wavelenth_file = '../support/hifidelity_wavelengths.txt'
-        self.earth_sun_distance_file = '../support/earth_sun_distance.txt'
-        self.irradiance_file = '../support/prism_optimized_irr.dat'
+    def __init__(self, args, training=True):
 
-        if args.training:
-            self.lut_modtran_directory = '../modtran_lut'
-            self.lut_sixs_directory = '../sixs_lut'
+        working_dir = args.dir
+
+        self.support_dir = os.path.join(working_dir, 'support')
+        self.template_dir = os.path.join(working_dir, 'templates')
+
+        # Make dirs
+        os.makedirs(self.support_dir, exist_ok=True)
+        os.makedirs(self.template_dir, exist_ok=True)
+
+        self.modtran_template_file = os.path.join(
+            self.template_dir, 'modtran_template.json'
+        )
+
+        if training:
+            self.isofit_config_file = os.path.join(
+                self.template_dir, 'isofit_template_v2.json'
+            )
         else:
-            self.lut_modtran_directory = '../modtran_lut_holdout_az'
-            self.lut_sixs_directory = '../sixs_lut_holdout_az'
+            self.isofit_config_file = os.path.join(
+                self.template_dir, 'isofit_template_holdout.json'
+            )
 
-        self.modtran_template_path = modtran_tpl
+        self.aerosol_tpl_path =  os.path.join(
+            self.support_dir, 
+            'aerosol_template.json'
+        )
+        self.aerosol_model_path =  os.path.join(
+            self.support_dir,
+            'aerosol_model.txt'
+        )
+        self.wavelength_file = os.path.join(
+            self.support_dir,
+            'hifidelity_wavelengths.txt'
+        )
+
+        # If we want to format this with the data repo
+        # self.earth_sun_distance_file = str(env.path("data", "emit_noise.txt")
+        self.earth_sun_distance_file = os.path.join(
+            self.support_dir,
+            'earth_sun_distance.txt'
+        )
+        self.irradiance_file = os.path.join(
+            self.support_dir,
+            'prism_optimized_irr.dat'
+        )
+
+        if training:
+            self.lut_modtran_directory = os.path.join(
+                working_dir,
+                'modtran_lut'
+            )
+            self.lut_sixs_directory = os.path.join(
+                working_dir,
+                'sixs_lut'
+            )
+        else:
+            self.lut_modtran_directory = os.path.join(
+                working_dir,
+                'modtran_lut_holdout_az'
+            )
+            self.lut_sixs_directory = os.path.join(
+                working_dir,
+                'sixs_lut_holdout_az'
+            )
+
+        os.makedirs(self.lut_modtran_directory, exist_ok=True)
+        os.makedirs(self.lut_sixs_directory, exist_ok=True)
+
+        # RTE Installation
+        if args.modtran_path:
+            self.modtran_path = args.modtran_path
+        else:
+            self.modtran_path = os.getenv("MODTRAN_DIR", env.modtran)
+
+        if args.sixs_path:
+            self.sixs_path = args.sixs_path
+        else:
+            self.sixs_path = os.getenv("SIXS_DIR", env.sixs)
 
 
-def build_main_config(paths, config_output_path, to_solar_azimuth_lut_grid: np.array, to_solar_zenith_lut_grid: np.array, 
-                      aerfrac_2_lut_grid: np.array, h2o_lut_grid: np.array = None,
-                      elevation_lut_grid: np.array = None, altitude_lut_grid: np.array = None, to_sensor_azimuth_lut_grid: np.array = None,
-                      to_sensor_zenith_lut_grid: np.array = None, n_cores: int = 1):
+def build_main_config(
+    paths, 
+    h2o_lut_grid: np.array,
+    elevation_lut_grid: np.array,
+    altitude_lut_grid: np.array, 
+    to_sensor_zenith_lut_grid: np.array,
+    to_solar_zenith_lut_grid: np.array,
+    to_sensor_azimuth_lut_grid: np.array,
+    to_solar_azimuth_lut_grid: np.array,
+    relative_azimuth_lut_grid: np.array,
+    aerfrac_2_lut_grid: np.array,
+    config_output_path, 
+    configure_and_exit: bool = True,
+    ip_head: str = None,
+    redis_password: str = None,
+    n_cores: int = 1,
+):
     """ Write an isofit dummy config file, so we can pass in for luts.
 
     Args:
-        paths: object with relevant path information attatched
-        config_output_path: path to write config to
-        to_solar_azimuth_lut_grid: the to-solar azimuth angle look up table grid to build
-        to_solar_zenith_lut_grid: the to-solar zenith angle look up table grid to build
-        aerfrac_2_lut_grid: the aerosol 2 look up table grid isofit should use for this solve
-        h2o_lut_grid: the water vapor look up table grid isofit should use for this solve
-        elevation_lut_grid: the ground elevation look up table grid isofit should use for this solve
-        altitude_lut_grid: the acquisition altitude look up table grid isofit should use for this solve
-        to_sensor_azimuth_lut_grid: the to-sensor azimuth angle look up table grid isofit should use for this solve
-        to_sensor_zenith_lut_grid: the to-sensor zenith angle look up table grid isofit should use for this solve
-        n_cores: the number of cores to use during processing
+        paths:                      Object containing references to all relevant file locations
+        lut_params:                 Configuration parameters for the lut grid
+        h2o_lut_grid:               The water vapor look up table grid isofit should use for this solve
+        elevation_lut_grid:         The ground elevation look up table grid isofit should use for this solve
+        altitude_lut_grid:          The altitude elevation (km) look up table grid isofit should use for this solve
+        to_sensor_zenith_lut_grid:  The to-sensor zenith angle look up table grid isofit should use for this solve
+        to_solar_zenith_lut_grid:   The to-sun zenith angle look up table grid isofit should use for this solve
+        relative_azimuth_lut_grid:  The relative to-sun azimuth angle look up table grid isofit should use for
+        config_output_path:         Path to write config to
+        n_cores:                    The number of cores to use during processing
 
     """
 
-
+    # Initialize the RT config with the engines portion.
     radiative_transfer_config = {
-
             "radiative_transfer_engines": {
                 "modtran": {
                     "engine_name": 'modtran',
-                    "lut_path": paths.lut_modtran_directory,
-                    "template_file": paths.modtran_template_path,
-                    "wavelength_range": [350,2500],
+                    "sim_path": paths.lut_modtran_directory,
+                    "lut_path": os.path.join(
+                        paths.lut_modtran_directory,
+                        'lut.nc'
+                    ),
+                    "multipart_transmittance": False,
+                    "template_file": paths.modtran_template_file,
+                    "rte_configure_and_exit": configure_and_exit,
+                    "engine_base_dir": paths.modtran_path,
                     #lut_names - populated below
                     #statevector_names - populated below
                 },
                 "sixs": {
                     "engine_name": '6s',
-                    "lut_path": paths.lut_sixs_directory,
-                    "wavelength_range": [350, 2500],
+                    "sim_path": paths.lut_sixs_directory,
+                    "lut_path": os.path.join(
+                        paths.lut_sixs_directory,
+                        'lut.nc'
+                    ),
                     "irradiance_file": paths.irradiance_file,
                     "earth_sun_distance_file": paths.earth_sun_distance_file,
                     "month": 6, # irrelevant to readouts we care about
@@ -226,7 +425,11 @@ def build_main_config(paths, config_output_path, to_solar_azimuth_lut_grid: np.a
                     "viewaz": to_sensor_azimuth_lut_grid[0],
                     "viewzen": 180 - to_sensor_zenith_lut_grid[0],
                     "solaz": to_solar_azimuth_lut_grid[0],
-                    "solzen": to_solar_zenith_lut_grid[0]
+                    "solzen": to_solar_zenith_lut_grid[0],
+                    "multipart_transmittance": False,
+                    "template_file": paths.modtran_template_file,
+                    "rte_configure_and_exit": configure_and_exit,
+                    "engine_base_dir": paths.sixs_path,
                     # lut_names - populated below
                     # statevector_names - populated below
                 }
@@ -236,62 +439,180 @@ def build_main_config(paths, config_output_path, to_solar_azimuth_lut_grid: np.a
                 "H2O_ABSCO": 0.0
             }
     }
+
+    # Question to figure out: Do I need the second key on a lot of these?
+    # H2O LUT Grid
     if h2o_lut_grid is not None and len(h2o_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['H2OSTR'] = [max(0.0, float(q)) for q in h2o_lut_grid]
+        radiative_transfer_config['lut_grid']['H2OSTR'] = [
+            max(0.0, float(q)) for q in h2o_lut_grid
+        ]
 
+    # Elevation LUT Grid
     if elevation_lut_grid is not None and len(elevation_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['GNDALT'] = [max(0.0, float(q)) for q in elevation_lut_grid]
-        radiative_transfer_config['lut_grid']['elev'] = [float(q) for q in elevation_lut_grid]
+        radiative_transfer_config['lut_grid']['surface_elevation_km'] = [
+            max(0.0, float(q)) for q in elevation_lut_grid
+        ]
 
+    # Altitude LUT Grid
     if altitude_lut_grid is not None and len(altitude_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['H1ALT'] = [max(0.0, float(q)) for q in altitude_lut_grid]
-        radiative_transfer_config['lut_grid']['alt'] = [float(q) for q in altitude_lut_grid]
+        radiative_transfer_config['lut_grid']['observer_altitude_km'] = [
+            max(0.0, float(q)) for q in altitude_lut_grid
+        ]
+        # radiative_transfer_config['lut_grid']['alt'] = [
+        #     float(q) for q in altitude_lut_grid
+        # ]
 
-    if to_sensor_azimuth_lut_grid is not None and len(to_sensor_azimuth_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['TRUEAZ'] = [float(q) for q in to_sensor_azimuth_lut_grid]
-        radiative_transfer_config['lut_grid']['viewaz'] = [float(q) for q in to_sensor_azimuth_lut_grid]
+    # Observer Zenith LUT Grid
+    if (
+        to_sensor_zenith_lut_grid is not None 
+        and len(to_sensor_zenith_lut_grid) > 1
+    ):
+        # Does Sixs? automatically convert value from Modtran convention
+        # Don't think so. Happens in template_construction.py
+        # Do I have to carry these as two keys?
+        # radiative_transfer_config['lut_grid']['observer_zenith'] = [
+        #     float(q) for q in to_sensor_zenith_lut_grid
+        # ]
+        # Sixs convension
+        # radiative_transfer_config['lut_grid']['viewzen'] = [
+        radiative_transfer_config['lut_grid']['observer_zenith'] = [
+            180 - float(q) for q in to_sensor_zenith_lut_grid
+        ] 
 
-    if to_sensor_zenith_lut_grid is not None and len(to_sensor_zenith_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['OBSZEN'] = [float(q) for q in to_sensor_zenith_lut_grid] # modtran convension
-        radiative_transfer_config['lut_grid']['viewzen'] = [180 - float(q) for q in to_sensor_zenith_lut_grid] # sixs convension
+    # Solar  Zenith LUT Grid
+    if (
+        to_solar_zenith_lut_grid is not None 
+        and len(to_solar_zenith_lut_grid) > 1
+    ):
+        # Modtran convension
+        radiative_transfer_config['lut_grid']['solar_zenith'] = [
+            float(q) for q in to_solar_zenith_lut_grid
+        ]
 
-    if to_solar_zenith_lut_grid is not None and len(to_solar_zenith_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['solzen'] = [float(q) for q in to_solar_zenith_lut_grid] # modtran convension
+    # Azimuth LUT Grid
+    if (
+        relative_azimuth_lut_grid is not None 
+        and len(relative_azimuth_lut_grid) > 1
+    ):
+        radiative_transfer_config["lut_grid"]["relative_azimuth"] = [
+            float(q) for q in relative_azimuth_lut_grid
+        ]
 
-    if to_solar_azimuth_lut_grid is not None and len(to_solar_azimuth_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['solaz'] = [float(q) for q in to_solar_azimuth_lut_grid] # modtran convension
-
-    # add aerosol elements from climatology
+    # Aerosol LUT Grid
+    # Should be able to use AERFRAC_2 for both
     if len(aerfrac_2_lut_grid) > 1:
-        radiative_transfer_config['lut_grid']['AERFRAC_2'] = [float(q) for q in aerfrac_2_lut_grid]
-        radiative_transfer_config['lut_grid']['AOT550'] = [float(q) for q in aerfrac_2_lut_grid]
+        radiative_transfer_config['lut_grid']['AERFRAC_2'] = [
+            float(q) for q in aerfrac_2_lut_grid
+        ]
+        # radiative_transfer_config['lut_grid']['AOT550'] = [
+        #     float(q) for q in aerfrac_2_lut_grid
+        # ]
 
     if paths.aerosol_model_path is not None:
-        radiative_transfer_config['radiative_transfer_engines']['modtran']['aerosol_model_file'] = paths.aerosol_model_path
+        radiative_transfer_config[
+            'radiative_transfer_engines'
+        ]['modtran']['aerosol_model_file'] = paths.aerosol_model_path
+
     if paths.aerosol_tpl_path is not None:
-        radiative_transfer_config['radiative_transfer_engines']['modtran']["aerosol_template_file"] = paths.aerosol_tpl_path
+        radiative_transfer_config[
+            'radiative_transfer_engines'
+        ]['modtran']["aerosol_template_file"] = paths.aerosol_tpl_path
 
     # MODTRAN should know about our whole LUT grid and all of our statevectors, so copy them in
-    radiative_transfer_config['radiative_transfer_engines']['modtran']['lut_names'] = [x for x in ['H2OSTR','AERFRAC_2','GNDALT','H1ALT','TRUEAZ','OBSZEN', 'solzen','solaz'] if x in radiative_transfer_config['lut_grid'].keys()]
-    radiative_transfer_config['radiative_transfer_engines']['sixs']['lut_names'] = [x for x in ['H2OSTR','AOT550','elev','alt','viewaz','viewzen','solzen','solaz'] if x in radiative_transfer_config['lut_grid'].keys()]
+    # Populate the lut_names and the statevector_names
+    modtran_lut_names = {
+        x: None for x in [
+            'H2OSTR','surface_elevation_km','observer_altitude_km',
+            'observer_zenith','solar_zenith', 'relative_azimuth',
+            'AERFRAC_2'
+        ] if x in radiative_transfer_config['lut_grid'].keys()
+    }
+    radiative_transfer_config[
+        'radiative_transfer_engines'
+    ]['modtran']['lut_names'] = modtran_lut_names
+    radiative_transfer_config["radiative_transfer_engines"]["modtran"][
+        "statevector_names"] = list(modtran_lut_names.keys())
+
+    sixs_lut_names = {
+        x: None for x in [
+            'H2OSTR','surface_elevation_km','observer_altitude_km',
+            # 'viewzen','solar_zenith', 'relative_azimuth',
+            'observer_zenith','solar_zenith', 'relative_azimuth',
+            'AERFRAC_2'
+        ] if x in radiative_transfer_config['lut_grid'].keys()
+    }
+    radiative_transfer_config[
+        'radiative_transfer_engines'
+    ]['sixs']['lut_names'] = sixs_lut_names
+    radiative_transfer_config["radiative_transfer_engines"]["sixs"][
+        "statevector_names"
+    ] = list(sixs_lut_names.keys())
+
+    # Inversion windows - Not sure what to use here
+    # inversion_windows = [[1,2],[3,4]]
+    inversion_windows = [[350.0, 1360.0], [1410, 1800.0], [1970.0, 2500.0]]
 
     # make isofit configuration
-    isofit_config_modtran = {'input': {},
-                             'output': {},
-                             'forward_model': {
-                                 "radiative_transfer": radiative_transfer_config,
-                                 "instrument": {"wavelength_file": paths.wavelenth_file}
-                             },
-                             "implementation": {
-                                "inversion": {"windows": [[1,2],[3,4]]},
-                                "n_cores": n_cores}
-                             }
-
+    isofit_config_modtran = {
+        'input': {},
+        'output': {}, 
+        'forward_model': {
+            "radiative_transfer": radiative_transfer_config,
+            "instrument": {"wavelength_file": paths.wavelength_file}
+        },
+        "implementation": {
+            "inversion": {"windows": inversion_windows},
+            "n_cores": n_cores,
+            "ip_head": ip_head,
+            "redis_password": redis_password
+        }
+    }
     isofit_config_modtran['implementation']["rte_configure_and_exit"] = True
 
     # write modtran_template
     with open(config_output_path, 'w') as fout:
-        fout.write(json.dumps(isofit_config_modtran, cls=SerialEncoder, indent=4, sort_keys=True))
+        fout.write(json.dumps(
+            isofit_config_modtran, 
+            cls=SerialEncoder, 
+            indent=4, 
+            sort_keys=True
+        ))
+
+
+def sobol_lut():
+    to_solar_zenith_lut = [0, 12.5, 25, 37.5, 50]
+    to_solar_azimuth_lut = [180]
+    to_sensor_azimuth_lut = [180]
+    to_sensor_zenith_lut = [140, 160, 180]
+    altitude_km_lut = [2, 4, 7, 10, 15, 25]
+    elevation_km_lut = [0, 0.75, 1.5, 2.25, 4.5]
+    h2o_lut_grid = (
+        np.round(np.linspace(0.1, 5, num=5), 3).tolist() + [0.6125]
+    )
+    h2o_lut_grid.sort()
+    aerfrac_2_lut_grid = (
+        np.round(np.linspace(0.01, 1, num=5), 3).tolist() + [0.5]
+    )
+    aerfrac_2_lut_grid.sort()
+
+    # Create a Sobol sequence generator
+    sobol = qmc.Sobol(d=2, scramble=False)  # d is the number of dimensions
+
+    # Generate 100 Sobol points
+    sample = sobol.random(n=100)
+
+    # Scale to the desired range (e.g., [0, 1])
+    sample = qmc.scale(sample, l_bounds=[0, 0], u_bounds=[1, 1])
+
+
+    relative_azimuth_lut = np.abs(
+        np.array(to_solar_azimuth_lut) 
+        - np.array(to_sensor_azimuth_lut)
+    )
+    relative_azimuth_lut = np.minimum(
+        relative_azimuth_lut, 
+        360 - relative_azimuth_lut
+    )
 
 
 if __name__ == '__main__':

--- a/build_luts.py
+++ b/build_luts.py
@@ -227,9 +227,15 @@ def main():
     with open(paths.modtran_template_file, 'r') as f:
         modtran_config = json.load(f)
 
-    modtran_config['MODTRAN'][0]['MODTRANINPUT']['GEOMETRY']['IPARM'] = 12
-    modtran_config['MODTRAN'][0]['MODTRANINPUT']['ATMOSPHERE']['H2OOPT'] = '+'
-    modtran_config['MODTRAN'][0]['MODTRANINPUT']['AEROSOLS']['VIS'] = 100
+    for n in range(len(modtran_config['MODTRAN'])):
+        modtran_config['MODTRAN'][n]['MODTRANINPUT']['GEOMETRY']['IPARM'] = 12
+        modtran_config['MODTRAN'][n]['MODTRANINPUT']['ATMOSPHERE']['H2OOPT'] = '+'
+        modtran_config['MODTRAN'][n]['MODTRANINPUT']['AEROSOLS']['VIS'] = 100
+        if args.coarse is not None:
+            modtran_config['MODTRAN'][n]['MODTRANINPUT']['SPECTRAL']['BMNAME'] = '05_2013'
+            modtran_config['MODTRAN'][n]['MODTRANINPUT']['SPECTRAL']['DV'] = 5
+            modtran_config['MODTRAN'][n]['MODTRANINPUT']['SPECTRAL']['FWHM'] = 5
+            
     with open(paths.modtran_template_file, 'w') as fout:
         fout.write(json.dumps(
             modtran_config, 
@@ -302,7 +308,7 @@ def main():
         for key in _keys
     }
     params["engine_config"] = modtran_engine_config 
-    params["build_interpolator"] = False 
+    params["build_interpolators"] = False 
     params['lut_grid'] = {
         key: params['lut_grid'][key] for key in
         modtran_engine_config.lut_names.keys()
@@ -317,7 +323,7 @@ def main():
         for key in _keys
     }
     params["engine_config"] = sixs_engine_config 
-    params["build_interpolator"] = False 
+    params["build_interpolators"] = False 
     params['lut_grid'] = {
         key: params['lut_grid'][key] for key in
         sixs_engine_config.lut_names.keys()
@@ -581,9 +587,9 @@ def build_main_config(
         radiative_transfer_config['lut_grid']['AERFRAC_2'] = [
             float(q) for q in aerfrac_2_lut_grid
         ]
-        # radiative_transfer_config['lut_grid']['AOT550'] = [
-        #     float(q) for q in aerfrac_2_lut_grid
-        # ]
+        radiative_transfer_config['lut_grid']['AOT550'] = [
+            float(q) for q in aerfrac_2_lut_grid
+        ]
 
     if paths.aerosol_model_path is not None:
         radiative_transfer_config[
@@ -615,7 +621,7 @@ def build_main_config(
             'H2OSTR','surface_elevation_km','observer_altitude_km',
             # 'viewzen','solar_zenith', 'relative_azimuth',
             'observer_zenith','solar_zenith', 'relative_azimuth',
-            'AERFRAC_2'
+            'AOT550'
         ] if x in radiative_transfer_config['lut_grid'].keys()
     }
     radiative_transfer_config[

--- a/build_luts.py
+++ b/build_luts.py
@@ -122,29 +122,32 @@ def main():
         if args.train:
             grid = {
                 #'to_solar_zenith_lut': [0, 12.5, 25, 37.5, 50],
+                'to_solar_zenith_lut': [0, 30, 60],
                 #'to_solar_azimuth_lut': [0, 60, 120, 180],
-                #'to_sensor_azimuth_lut': [0],
-                #'to_sensor_zenith_lut': [140, 160, 180],
-                #'altitude_km_lut': [2, 4, 7, 10, 15, 25, 99],
+                'to_solar_azimuth_lut': [0, 90, 180],
+                'to_sensor_azimuth_lut': [0],
+                'to_sensor_zenith_lut': [140, 160, 180],
+                'altitude_km_lut': [2, 4, 7, 10, 15, 25, 99],
                 #'elevation_km_lut': [0, 0.75, 1.5, 2.25, 4.5, 6],
+                'elevation_km_lut': [0, 1.5, 4.5, 6],
+                'h2o_lut': list(np.sort(
+                    np.round(np.linspace(0.1, 5, num=5), 3).tolist()
+                )),
+                'aerfrac_2_lut': list(np.sort(
+                    np.round(np.linspace(0.01, 1, num=5), 3).tolist()
+                ))
+                #'to_solar_zenith_lut': [0, 50],
+                #'to_solar_azimuth_lut': [0, 180],
+                #'to_sensor_azimuth_lut': [0],
+                #'to_sensor_zenith_lut': [140, 180],
+                #'altitude_km_lut': [2, 99],
+                #'elevation_km_lut': [0, 6],
                 #'h2o_lut': list(np.sort(
-                #    np.round(np.linspace(0.1, 5, num=5), 3).tolist() + [0.6125]
+                #    np.round(np.linspace(0.1, 5, num=2), 3).tolist() + [0.6125]
                 #)),
                 #'aerfrac_2_lut': list(np.sort(
                 #    np.round(np.linspace(0.01, 1, num=5), 3).tolist() + [0.5]
                 #))
-                'to_solar_zenith_lut': [0, 50],
-                'to_solar_azimuth_lut': [0, 180],
-                'to_sensor_azimuth_lut': [0],
-                'to_sensor_zenith_lut': [140, 180],
-                'altitude_km_lut': [2, 99],
-                'elevation_km_lut': [0, 6],
-                'h2o_lut': list(np.sort(
-                    np.round(np.linspace(0.1, 5, num=2), 3).tolist() + [0.6125]
-                )),
-                'aerfrac_2_lut': list(np.sort(
-                    np.round(np.linspace(0.01, 1, num=5), 3).tolist() + [0.5]
-                ))
             }
             relative_azimuth_lut = np.abs(
                 np.array(grid['to_solar_azimuth_lut']) 
@@ -299,6 +302,7 @@ def main():
         for key in _keys
     }
     params["engine_config"] = modtran_engine_config 
+    params["build_interpolator"] = False 
     params['lut_grid'] = {
         key: params['lut_grid'][key] for key in
         modtran_engine_config.lut_names.keys()
@@ -313,6 +317,7 @@ def main():
         for key in _keys
     }
     params["engine_config"] = sixs_engine_config 
+    params["build_interpolator"] = False 
     params['lut_grid'] = {
         key: params['lut_grid'][key] for key in
         sixs_engine_config.lut_names.keys()
@@ -471,6 +476,8 @@ def build_main_config(
                         paths.lut_modtran_directory,
                         'lut.nc'
                     ),
+                    "rt_mode": 'rdn',
+                    "irradiance_file": paths.irradiance_file,
                     "multipart_transmittance": True,
                     "template_file": paths.modtran_template_file,
                     "rte_configure_and_exit": configure_and_exit,
@@ -480,6 +487,7 @@ def build_main_config(
                 },
                 "sixs": {
                     "engine_name": '6s',
+                    "rt_mode": 'rdn',
                     "sim_path": paths.lut_sixs_directory,
                     "lut_path": os.path.join(
                         paths.lut_sixs_directory,

--- a/build_luts.py
+++ b/build_luts.py
@@ -132,7 +132,7 @@ def main():
                 'elevation_km_lut': [0, 1.5, 4.5, 6],
                 'h2o_lut': list(np.sort(
                     np.round(np.linspace(0.1, 5, num=5), 3).tolist()
-                )) + [0.7125, 1.9375, 3.162, 4.3875],
+                )), #+ [0.7125, 1.9375, 3.162, 4.3875],
                 'aerfrac_2_lut': list(np.sort(
                     np.round(np.linspace(0.01, 1, num=5), 3).tolist()
                 ))
@@ -193,14 +193,15 @@ def main():
     print('Expected MODTRAN runtime: {} hrs'.format(n_lut_build*1.5))
     print('Expected MODTRAN runtime: {} days'.format(n_lut_build*1.5/24))
     print('Expected MODTRAN runtime per (40-core) node: {} days'.format(n_lut_build*1.5/24/40))
+
     
     # Create wavelength file
     if args.coarse is None:
-        wl = np.arange(0.350, 2.550, 0.0005)
+        wl = np.arange(0.350, 2.550, 0.0001)
         wl_file_contents = np.zeros((len(wl),3))
         wl_file_contents[:,0] = np.arange(len(wl),dtype=int)
         wl_file_contents[:,1] = wl
-        wl_file_contents[:,2] = 0.0005
+        wl_file_contents[:,2] = 0.0001
 
         np.savetxt(
             paths.wavelength_file, 
@@ -329,6 +330,12 @@ def main():
         sixs_engine_config.lut_names.keys()
     }
     # params['modtran_emulation'] = True
+
+    # always overwrite 6S wavelength with full raw 6S range
+    sixs_wl = np.arange(350, 2500 + 2.5, 2.5)
+    sixs_fwhm = np.full(sixs_wl.size, 2.0)
+    params['wl'] = sixs_wl
+    params['fwhm'] = sixs_fwhm
     isofit_sixs = SixSRT(**params)
 
     # cleanup

--- a/build_luts.py
+++ b/build_luts.py
@@ -148,6 +148,7 @@ def main():
                 'to_solar_zenith_lut': [0, 30, 60],
                 #'to_solar_azimuth_lut': [0, 60, 120, 180],
                 'to_solar_azimuth_lut': [0, 90, 180],
+                'to_sensor_azimuth_lut': [0],
                 'to_sensor_zenith_lut': [140, 160, 180],
                 'altitude_km_lut': [2, 4, 7, 10, 15, 25, 99],
                 #'elevation_km_lut': [0, 0.75, 1.5, 2.25, 4.5, 6],

--- a/convolve.py
+++ b/convolve.py
@@ -14,131 +14,6 @@ import ray
 import multiprocessing as mp
 
 
-class resample():
-    """ Resampling class where you can initialize and then use. It has a saftey logic against non finite
-    elements in the data to interpoloate. 
-
-    Args:
-        wvs_a: High resolution data's spectral grid
-        wvs_b: Instrument's resolution spectra grid
-        fwhm_b: Instrument's FWHM
-    """
-    def __init__(self, wvs_a, wvs_b, fwhm_b):
-        self.wvs_a = wvs_a
-        self.wvs_b = wvs_b
-        self.fwhm_b = fwhm_b
-        self.get_transform_matrix()
-
-    
-    def get_transform_matrix(self):
-        base_wl = np.array(self.wvs_a)
-        self.base_wl = base_wl
-        target_wl = np.array(self.wvs_b)
-        self.target_wl = target_wl
-        target_fwhm = np.array(self.fwhm_b)
-
-        doTheResample = lambda id: self.spectrumResample(id, base_wl, target_wl, target_fwhm)
-        ww = np.array([doTheResample(W) for W in range(len(target_wl))])
-        self.transform_matrix = ww
-    
-
-    def process_data(self, ys, n_samples, num_processes=4):
-        """
-        Process data in parallel.
-        Args:
-            ys: The data to be processed.
-            n_samples: The number of samples expected in ys.
-            num_processes: The number of parallel processes to use.
-        Returns:
-            Processed data.
-        """
-        num_processes = mp.cpu_count()
-        # Check dimensions and align correctly
-        ys = self._reshape_data(ys, n_samples)
-
-        # Initialize Ray
-        #if not ray.is_initialized():
-        #    ray.init(num_cpus=num_processes)
-
-        # Dispatch tasks
-        #result_ids = [self.process_single_sample.remote(self, ys[i, :]) for i in range(ys.shape[0])]
-        #results = ray.get(result_ids)
-        results = [self.process_single_sample(ys[i, :],i) for i in range(ys.shape[0])]
-
-        return np.array(results)
-
-    #@ray.remote(num_cpus=1)
-    def process_single_sample(self, y, i):
-        """
-        Process a single sample. This method will be called in parallel.
-        Args:
-            y: A single sample from ys.
-        Returns:
-            The processed sample.
-        """
-        # Processing logic for a single sample
-        # For example, this could be a call to self.__call__(y) or other processing
-        if i % 100:
-            print(i)
-        return self.__call__(y)  # or other processing logic
-
-
-    def _reshape_data(self, ys, n_samples):
-        """
-        Reshape data to the correct dimensions for convolution.
-        """
-        counter = 0
-        max_attempts = 5
-        while ys.shape[0] != n_samples:
-            if counter >= max_attempts:
-                raise ValueError("Unable to reshape data to the correct dimensions for convolution")
-            ys = ys.T
-            counter += 1
-        return ys
-
-    def __call__(self, y):
-        # Convert input to 2D array and transpose if necessary
-
-        # Convert input to 2D array
-        spectrum = np.atleast_2d(y)
-
-        # Check if transpose is necessary
-        transpose_needed = spectrum.shape[0] == 1
-
-        # Initialize an output array
-        resampled_spectrum = np.zeros(self.transform_matrix.shape[0])
-
-        # Identify valid (non-NaN, non-inf, non--inf) elements in the spectrum
-        valid_indices = np.isfinite(spectrum[0]) if transpose_needed else np.isfinite(spectrum[:, 0])
-
-        # Optimize the loop with vectorized operations
-        if transpose_needed:
-            spectrum = spectrum.T
-
-        resampled_spectrum = np.dot(self.transform_matrix[:, valid_indices], spectrum[valid_indices])
-
-        return np.squeeze(resampled_spectrum)
-
-
-    def srf(self, x, mu, sigma):
-        """Spectral Response Function """
-        u = (x-mu)/abs(sigma)
-        y = (1.0/(np.sqrt(2.0*np.pi)*abs(sigma)))*np.exp(-u*u/2.0)
-        if y.sum()==0:
-            return y
-        else:
-            return y/y.sum()
-
-
-    def spectrumResample(self, idx, wl, wl2, fwhm2=10, fill=False):
-        """Resample a spectrum to a new wavelength / FWHM.
-        I assume Gaussian SRFs"""
-
-        resampled = np.array(self.srf(wl, wl2[idx], fwhm2[idx]/2.35482))
-
-
-        return resampled
-
 
 def spectral_response_function(response_range: np.array, mu: float, sigma: float):
     """Calculate the spectral response function.
@@ -223,46 +98,69 @@ def main():
 
     output_sixs = None
     output_sixs_wl = None
+    npzf = np.load(args.input_file)
+
+
+    # SIXS
+    input_sixs_wl = npzf['sixs_wavelengths']
+
+
+    input_sixs = npzf['sixs_results'].copy()
+    input_solar_irr = npzf['sol_irr']
+    points = npzf['points']
+    point_names = npzf['point_names'].tolist()
+
     if args.output_sixs_wl_file is not None:
+        if args.irr_file is not None:
+            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
+            irr = irr / 10  # convert to uW cm-2 sr-1 nm-1
+            input_sixs_irr = np.array(resample_spectrum(irr, irr_wl, input_sixs_wl, np.ones(len(irr_wl))*(input_sixs_wl[1]-input_sixs_wl[0])),dtype=np.float32)
 
-        npzf = np.load(args.input_file)
-        input_sixs_wl = npzf['sixs_wavelengths']
-
+        n_bands = int(input_sixs.shape[1] / len(npzf['keys']))
+        for key in range(len(npzf['keys'])):
+            input_sixs[:, n_bands * key : n_bands * (key + 1)] = input_sixs[:, n_bands * key : n_bands * (key + 1)] * input_sixs_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))[:,np.newaxis]
+        
         output_sixs_wl = np.genfromtxt(args.output_sixs_wl_file)[:, 1]
         output_sixs_fwhm = np.genfromtxt(args.output_sixs_wl_file)[:, 2]
         if np.all(output_sixs_wl < 1000):
             output_sixs_wl *= 1000
             output_sixs_fwhm *= 1000
-        
+
+        output_sixs_irr = np.array(resample_spectrum(irr, irr_wl, output_sixs_wl, output_sixs_fwhm),dtype=np.float32)
         H = np.array( [ spectral_response_function(input_sixs_wl, wi, fwhmi) for wi, fwhmi in zip(output_sixs_wl, output_sixs_fwhm) ] )
         H[np.isnan(H)] = 0
-
-        input_sixs = npzf['sixs_results'].copy()
-        input_solar_irr = npzf['solar_irradiance']
-        points = npzf['points']
-        point_names = npzf['point_names']
-
-        if args.irr_file is not None:
-            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
-            irr = irr / 10  # convert to uW cm-2 sr-1 nm-1
-            input_sixs_irr = np.array(resample_spectrum(irr, irr_wl, input_sixs_wl, input_sixs_wl[1]-input_sixs_wl[0]),dtype=np.float32)
-
-        n_bands = int(input_sixs.shape[1] / len(npzf['keys']))
+        output_sixs = np.zeros((input_sixs.shape[0], len(output_sixs_wl)*len(npzf['keys'])))
+        n_bands_o = len(output_sixs_wl)
         for key in range(len(npzf['keys'])):
-            input_sixs[:, n_bands * key : n_bands * (key + 1)] = input_sixs[:, n_bands * key : n_bands * (key + 1)] * input_sixs_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))
-        
-        output_sixs = np.dot(input_sixs, H.T)
+            output_sixs[:, n_bands_o * key : n_bands_o * (key + 1)] = np.dot(input_sixs[:, n_bands * key : n_bands * (key + 1)], H.T) / output_sixs_irr / np.pi * np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))[:,np.newaxis]
         print(output_sixs.shape)
     else:
-        output_sixs = npzf['sixs_results']
+        output_sixs = input_sixs
         output_sixs_wl = npzf['sixs_wavelengths']
     
+
+    # MODTRAN
     output_modtran = None
     output_solar_irr = None
     output_modtran_wl = None
+    input_modtran_wl = npzf['modtran_wavelengths']
+
+
+    input_modtran = npzf['modtran_results'].copy()
+    input_solar_irr = npzf['sol_irr']
+    points = npzf['points']
+    point_names = npzf['point_names'].tolist()
+
     if args.output_modtran_wl_file is not None:
-        npzf = np.load(args.input_file)
-        input_modtran_wl = npzf['modtran_wavelengths']
+        if args.irr_file is not None:
+            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
+            irr = irr / 10
+            input_modtran_irr = np.array(resample_spectrum(irr, irr_wl, input_modtran_wl, np.ones(len(irr_wl))*(input_modtran_wl[1] - input_modtran_wl[0])),dtype=np.float32)
+
+        n_bands = int(input_modtran.shape[1] / len(npzf['keys']))
+        #for key in range(len(npzf['keys'])):
+        #    input_modtran[:, n_bands * key : n_bands * (key + 1)] = input_modtran[:, n_bands * key : n_bands * (key + 1)] * input_modtran_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))[:,np.newaxis]
+
 
         output_modtran_wl = np.genfromtxt(args.output_modtran_wl_file)[:, 1]
         output_modtran_fwhm = np.genfromtxt(args.output_modtran_wl_file)[:, 2]
@@ -270,29 +168,23 @@ def main():
             output_modtran_wl *= 1000
             output_modtran_fwhm *= 1000
 
+        output_modtran_irr = np.array(resample_spectrum(irr, irr_wl, output_modtran_wl, output_modtran_fwhm),dtype=np.float32)
         H = np.array( [ spectral_response_function(input_modtran_wl, wi, fwhmi) for wi, fwhmi in zip(output_modtran_wl, output_modtran_fwhm) ] )
         H[np.isnan(H)] = 0
-
-        input_modtran = npzf['modtran_results'].copy()
-        input_solar_irr = npzf['solar_irradiance']
-        points = npzf['points']
-
-        if args.irr_file is not None:
-            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
-            irr = irr / 10
-            input_modtran_irr = np.array(resample_spectrum(irr, irr_wl, input_modtran_wl, input_modtran_wl[1] - input_modtran_wl[0]),dtype=np.float32)
-            output_modtran_irr = np.array(resample_spectrum(irr, irr_wl, output_modtran_wl, output_modtran_fwhm),dtype=np.float32)
-
-        n_bands = int(input_modtran.shape[1] / len(npzf['keys']))
+        output_modtran = np.zeros((input_modtran.shape[0], len(output_modtran_wl)*len(npzf['keys'])))
+        n_bands_o = len(output_modtran_wl)
+        input_modtran[np.isfinite(input_modtran) == False] = 0
         for key in range(len(npzf['keys'])):
-            input_modtran[:, n_bands * key : n_bands * (key + 1)] = input_modtran[:, n_bands * key : n_bands * (key + 1)] * input_modtran_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))
-
-        output_modtran = np.dot(input_modtran, H.T)
+            print(n_bands_o * key , n_bands_o * (key + 1), n_bands * key , n_bands * (key + 1))
+            output_modtran[:, n_bands_o * key : n_bands_o * (key + 1)] = np.dot(H, input_modtran[:, n_bands * key : n_bands * (key + 1)].T).T #/ output_modtran_irr / np.pi * np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))[:,np.newaxis]
+            #import ipdb; ipdb.set_trace()
+            #test=resample_spectrum(input_modtran[0, n_bands * key : n_bands * (key + 1)], input_modtran_wl, output_modtran_wl, output_modtran_fwhm)
+            
         print(output_modtran.shape)
 
 
     else:
-        output_modtran = npzf['modtran_results']
+        output_modtran = input_modtran
         output_modtran_irr = npzf['sol_irr']
         output_modtran_wl = npzf['modtran_wavelengths']
     
@@ -313,127 +205,6 @@ def main():
 
 if __name__ == "__main__":
     main()
-#input_file = "/Users/brodrick/Downloads/emit_emulator_v1.hdf5"
-##out_file = "/Users/brodrick/Downloads/emit_emulator_v1_conv01.hdf5"
-#out_file = "/Users/brodrick/Downloads/emit_emulator_v1_conv_EMIT_Wavelengths_20220817_clipped.hdf5"
-#out_file = "/Users/brodrick/repos/kf/convolved/neon_emulator_v1_conv.hdf5"
-#subprocess.call(f"cp {input_file} {out_file}", shell=True)
-
-input_file = "data_202411121/emit_emulator_v2_0.hdf5"
-out_file = "data_202411121/emit_emulator_v2_conv_EMIT_Wavelengths_20220817_clipped.hdf5"
-
-input =  h5py.File(input_file, "r")
-output = h5py.File(out_file, "w")
-
-def copy_groups(name, obj):
-    if isinstance(obj, h5py.Group):
-        output.create_group(name)
-input.visititems(copy_groups)
-
-def copy_attributes(name, obj):
-    if isinstance(obj, h5py.Group) or isinstance(obj, h5py.Dataset):
-        for key, value in obj.attrs.items():
-            output[name].attrs[key] = value
-input.visititems(copy_attributes)
-
-
-wl = input["MISCELLANEOUS"]["Wavelengths"][:]
-X = input["sample_space"]["sample space"][:,:]
-Y_all = input["mod_output/modtran output"][:,:,:]
-
-
-output_wl = np.genfromtxt('wl/EMIT_Wavelengths_20220817.txt')[:,1:][::-1,:]*1000
-subset = np.where((output_wl[:,0] >= wl[0]) & (output_wl[:,0] <= wl[-1]))[0]
-output_wl = output_wl[subset,:]
-subset = np.where((output_wl[:,0] >= 380) & (output_wl[:,0] <= 2493))[0]
-output_wl = output_wl[subset,:]
-#output_wl = np.genfromtxt('wl/neon_wl.txt')[:,1:]
-
-
-print('prepping')
-for key, value in input["sample_space"].items():
-    output.create_dataset(f"sample_space/{key}", data=value)
-for key, value in input["MISCELLANEOUS"].items():
-    output.create_dataset(f"MISCELLANEOUS/{key}", data=value)
-
-# overwrite wavelengths
-del output["MISCELLANEOUS/Wavelengths"]
-output["MISCELLANEOUS/Wavelengths"] = output_wl[:,0]
-
-yn = input['mod_output'].attrs['Products'].tolist()
-del input
-print('convolving')
-##res = resample(wl, np.arange(wl[0], wl[-1], 0.1), 0.1*np.ones(len(np.arange(wl[0], wl[-1], 0.1))))
-##res = resample(wl, np.arange(wl[0], wl[-1], 5.0), 5.0*np.ones(len(np.arange(wl[0], wl[-1], 5.0))))
-print(output_wl[:,0].shape)
-print(Y_all.shape)
-print(wl.shape)
-res = resample(wl, output_wl[:,0], output_wl[:,1])
-
-yn_out = []
-Y_out = []
-yn_out.append('path_radiance')
-Y_out.append(res.process_data(Y_all[:,yn.index('path_radiance'),:], Y_all.shape[0]))
-
-#yn_out.append('t_down_dir_t_up_dir')
-yn_out.append('bi-direct')
-Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dir'),:]*\
-                              Y_all[:,yn.index('t_up_dir'),:]*\
-                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
-
-#yn_out.append('t_down_dif_t_up_dir')
-yn_out.append('hemi-direct')
-Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dif'),:]*\
-                              Y_all[:,yn.index('t_up_dir'),:]*\
-                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
-
-#yn_out.append('t_down_dir_t_up_dif')
-yn_out.append('direct-hemi')
-Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dir'),:]*\
-                              Y_all[:,yn.index('t_up_dif'),:]*\
-                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
-
-#yn_out.append('t_down_dif_t_up_dif')
-yn_out.append('bi-hemi')
-Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dif'),:]*\
-                              Y_all[:,yn.index('t_up_dif'),:]*\
-                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
-
-yn_out.append('sphalb')
-Y_out.append(res.process_data(Y_all[:,yn.index('sphalb_num'),:]/\
-                              Y_all[:,yn.index('sphalb_denom'),:], Y_all.shape[0]))
-
-Y_out = np.stack(Y_out, axis=1)
-
-
-print('writing')
-output["mod_output/modtran output"] = Y_out
-output['mod_output'].attrs['Products'] = yn_out
-del output
-
-print('checking')
-input = h5py.File(out_file, "r")
-Y_all = input["mod_output/modtran output"][:,:,:]
-print(Y_all.shape)
-del input
-
-
-#Y_out = []
-#for n in range(Y_all.shape[1]):
-#    Y_out.append(res.process_data(Y_all[:,n,:], Y_all.shape[0]))
-#
-#Y_out = np.stack(Y_out, axis=1)
-#
-#del input["mod_output/modtran output"]
-#input["mod_output/modtran output"] = Y_out
-#del input["MISCELLANEOUS/Wavelengths"]
-#input["MISCELLANEOUS/Wavelengths"] = output_wl[:,0]
-#del input
-#input = h5py.File(out_file, "r")
-#Y_all = input["mod_output/modtran output"][:,:,:]
-#print(Y_all.shape)
-
-
 
 
 

--- a/convolve.py
+++ b/convolve.py
@@ -1,0 +1,443 @@
+
+
+
+
+
+
+
+import numpy as np
+import argparse
+import h5py
+import subprocess
+import os
+import ray
+import multiprocessing as mp
+
+
+class resample():
+    """ Resampling class where you can initialize and then use. It has a saftey logic against non finite
+    elements in the data to interpoloate. 
+
+    Args:
+        wvs_a: High resolution data's spectral grid
+        wvs_b: Instrument's resolution spectra grid
+        fwhm_b: Instrument's FWHM
+    """
+    def __init__(self, wvs_a, wvs_b, fwhm_b):
+        self.wvs_a = wvs_a
+        self.wvs_b = wvs_b
+        self.fwhm_b = fwhm_b
+        self.get_transform_matrix()
+
+    
+    def get_transform_matrix(self):
+        base_wl = np.array(self.wvs_a)
+        self.base_wl = base_wl
+        target_wl = np.array(self.wvs_b)
+        self.target_wl = target_wl
+        target_fwhm = np.array(self.fwhm_b)
+
+        doTheResample = lambda id: self.spectrumResample(id, base_wl, target_wl, target_fwhm)
+        ww = np.array([doTheResample(W) for W in range(len(target_wl))])
+        self.transform_matrix = ww
+    
+
+    def process_data(self, ys, n_samples, num_processes=4):
+        """
+        Process data in parallel.
+        Args:
+            ys: The data to be processed.
+            n_samples: The number of samples expected in ys.
+            num_processes: The number of parallel processes to use.
+        Returns:
+            Processed data.
+        """
+        num_processes = mp.cpu_count()
+        # Check dimensions and align correctly
+        ys = self._reshape_data(ys, n_samples)
+
+        # Initialize Ray
+        #if not ray.is_initialized():
+        #    ray.init(num_cpus=num_processes)
+
+        # Dispatch tasks
+        #result_ids = [self.process_single_sample.remote(self, ys[i, :]) for i in range(ys.shape[0])]
+        #results = ray.get(result_ids)
+        results = [self.process_single_sample(ys[i, :],i) for i in range(ys.shape[0])]
+
+        return np.array(results)
+
+    #@ray.remote(num_cpus=1)
+    def process_single_sample(self, y, i):
+        """
+        Process a single sample. This method will be called in parallel.
+        Args:
+            y: A single sample from ys.
+        Returns:
+            The processed sample.
+        """
+        # Processing logic for a single sample
+        # For example, this could be a call to self.__call__(y) or other processing
+        if i % 100:
+            print(i)
+        return self.__call__(y)  # or other processing logic
+
+
+    def _reshape_data(self, ys, n_samples):
+        """
+        Reshape data to the correct dimensions for convolution.
+        """
+        counter = 0
+        max_attempts = 5
+        while ys.shape[0] != n_samples:
+            if counter >= max_attempts:
+                raise ValueError("Unable to reshape data to the correct dimensions for convolution")
+            ys = ys.T
+            counter += 1
+        return ys
+
+    def __call__(self, y):
+        # Convert input to 2D array and transpose if necessary
+
+        # Convert input to 2D array
+        spectrum = np.atleast_2d(y)
+
+        # Check if transpose is necessary
+        transpose_needed = spectrum.shape[0] == 1
+
+        # Initialize an output array
+        resampled_spectrum = np.zeros(self.transform_matrix.shape[0])
+
+        # Identify valid (non-NaN, non-inf, non--inf) elements in the spectrum
+        valid_indices = np.isfinite(spectrum[0]) if transpose_needed else np.isfinite(spectrum[:, 0])
+
+        # Optimize the loop with vectorized operations
+        if transpose_needed:
+            spectrum = spectrum.T
+
+        resampled_spectrum = np.dot(self.transform_matrix[:, valid_indices], spectrum[valid_indices])
+
+        return np.squeeze(resampled_spectrum)
+
+
+    def srf(self, x, mu, sigma):
+        """Spectral Response Function """
+        u = (x-mu)/abs(sigma)
+        y = (1.0/(np.sqrt(2.0*np.pi)*abs(sigma)))*np.exp(-u*u/2.0)
+        if y.sum()==0:
+            return y
+        else:
+            return y/y.sum()
+
+
+    def spectrumResample(self, idx, wl, wl2, fwhm2=10, fill=False):
+        """Resample a spectrum to a new wavelength / FWHM.
+        I assume Gaussian SRFs"""
+
+        resampled = np.array(self.srf(wl, wl2[idx], fwhm2[idx]/2.35482))
+
+
+        return resampled
+
+
+def spectral_response_function(response_range: np.array, mu: float, sigma: float):
+    """Calculate the spectral response function.
+
+    Args:
+        response_range: signal range to calculate over
+        mu: mean signal value
+        sigma: signal variation
+
+    Returns:
+        np.array: spectral response function
+
+    """
+
+    u = (response_range - mu) / abs(sigma)
+    y = (1.0 / (np.sqrt(2.0 * np.pi) * abs(sigma))) * np.exp(-u * u / 2.0)
+    srf = y / y.sum()
+    return srf
+
+
+def resample_spectrum(
+    x: np.array, wl: np.array, wl2: np.array, fwhm2: np.array, fill: bool = False, H: np.array = None
+) -> np.array:
+    """Resample a spectrum to a new wavelength / FWHM.
+       Assumes Gaussian SRFs.
+
+    Args:
+        x: radiance vector
+        wl: sample starting wavelengths
+        wl2: wavelengths to resample to
+        fwhm2: full-width-half-max at resample resolution
+        fill: boolean indicating whether to fill in extrapolated regions
+
+    Returns:
+        np.array: interpolated radiance vector
+
+    """
+    if H is None:
+        H = np.array(
+            [
+                spectral_response_function(wl, wi, fwhmi / 2.355)
+                for wi, fwhmi in zip(wl2, fwhm2)
+            ]
+        )
+        H[np.isnan(H)] = 0
+
+    dims = len(x.shape)
+    if fill:
+        if dims > 1:
+            raise Exception("resample_spectrum(fill=True) only works with vectors")
+
+        x = x.reshape(-1, 1)
+        xnew = np.dot(H, x).ravel()
+        good = np.isfinite(xnew)
+        for i, xi in enumerate(xnew):
+            if not good[i]:
+                nearest_good_ind = np.argmin(abs(wl2[good] - wl2[i]))
+                xnew[i] = xnew[nearest_good_ind]
+        return xnew
+    else:
+        # Replace NaNs with zeros
+        x[np.isnan(x)] = 0
+
+        # Matrix
+        if dims > 1:
+            return np.dot(H, x.T).T
+
+        # Vector
+        else:
+            x = x.reshape(-1, 1)
+            return np.dot(H, x).ravel()
+
+
+def main():
+    parser = argparse.ArgumentParser(description="built luts for emulation.")
+    parser.add_argument('input_file', type=str)
+    parser.add_argument('output_file', type=str)
+    parser.add_argument('--output_sixs_wl_file', type=str, default=None)
+    parser.add_argument('--output_modtran_wl_file', type=str, default=None)
+    parser.add_argument('--irr_file', type=str, default=None)
+    args = parser.parse_args()
+
+    output_sixs = None
+    output_sixs_wl = None
+    if args.output_sixs_wl_file is not None:
+
+        npzf = np.load(args.input_file)
+        input_sixs_wl = npzf['sixs_wavelengths']
+
+        output_sixs_wl = np.genfromtxt(args.output_sixs_wl_file)[:, 1]
+        output_sixs_fwhm = np.genfromtxt(args.output_sixs_wl_file)[:, 2]
+        if np.all(output_sixs_wl < 1000):
+            output_sixs_wl *= 1000
+            output_sixs_fwhm *= 1000
+        
+        H = np.array( [ spectral_response_function(input_sixs_wl, wi, fwhmi) for wi, fwhmi in zip(output_sixs_wl, output_sixs_fwhm) ] )
+        H[np.isnan(H)] = 0
+
+        input_sixs = npzf['sixs_results'].copy()
+        input_solar_irr = npzf['solar_irradiance']
+        points = npzf['points']
+        point_names = npzf['point_names']
+
+        if args.irr_file is not None:
+            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
+            irr = irr / 10  # convert to uW cm-2 sr-1 nm-1
+            input_sixs_irr = np.array(resample_spectrum(irr, irr_wl, input_sixs_wl, input_sixs_wl[1]-input_sixs_wl[0]),dtype=np.float32)
+
+        n_bands = int(input_sixs.shape[1] / len(npzf['keys']))
+        for key in range(len(npzf['keys'])):
+            input_sixs[:, n_bands * key : n_bands * (key + 1)] = input_sixs[:, n_bands * key : n_bands * (key + 1)] * input_sixs_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))
+        
+        output_sixs = np.dot(input_sixs, H.T)
+        print(output_sixs.shape)
+    else:
+        output_sixs = npzf['sixs_results']
+        output_sixs_wl = npzf['sixs_wavelengths']
+    
+    output_modtran = None
+    output_solar_irr = None
+    output_modtran_wl = None
+    if args.output_modtran_wl_file is not None:
+        npzf = np.load(args.input_file)
+        input_modtran_wl = npzf['modtran_wavelengths']
+
+        output_modtran_wl = np.genfromtxt(args.output_modtran_wl_file)[:, 1]
+        output_modtran_fwhm = np.genfromtxt(args.output_modtran_wl_file)[:, 2]
+        if np.all(output_modtran_wl < 1000):
+            output_modtran_wl *= 1000
+            output_modtran_fwhm *= 1000
+
+        H = np.array( [ spectral_response_function(input_modtran_wl, wi, fwhmi) for wi, fwhmi in zip(output_modtran_wl, output_modtran_fwhm) ] )
+        H[np.isnan(H)] = 0
+
+        input_modtran = npzf['modtran_results'].copy()
+        input_solar_irr = npzf['solar_irradiance']
+        points = npzf['points']
+
+        if args.irr_file is not None:
+            irr_wl, irr = np.loadtxt(args.irr_file, comments="#").T
+            irr = irr / 10
+            input_modtran_irr = np.array(resample_spectrum(irr, irr_wl, input_modtran_wl, input_modtran_wl[1] - input_modtran_wl[0]),dtype=np.float32)
+            output_modtran_irr = np.array(resample_spectrum(irr, irr_wl, output_modtran_wl, output_modtran_fwhm),dtype=np.float32)
+
+        n_bands = int(input_modtran.shape[1] / len(npzf['keys']))
+        for key in range(len(npzf['keys'])):
+            input_modtran[:, n_bands * key : n_bands * (key + 1)] = input_modtran[:, n_bands * key : n_bands * (key + 1)] * input_modtran_irr * np.pi / np.cos(np.deg2rad(points[:, point_names.index('solar_zenith')]))
+
+        output_modtran = np.dot(input_modtran, H.T)
+        print(output_modtran.shape)
+
+
+    else:
+        output_modtran = npzf['modtran_results']
+        output_modtran_irr = npzf['sol_irr']
+        output_modtran_wl = npzf['modtran_wavelengths']
+    
+    
+    np.savez(args.output_file, modtran_results=output_modtran, 
+                         sixs_results=output_sixs, 
+                         points=npzf['points'],
+                         sol_irr=output_modtran_irr,
+                         sixs_wavelengths=output_sixs_wl,
+                         modtran_wavelengths=output_modtran_wl,
+                         point_names=npzf['point_names'],  
+                         keys=npzf['keys']
+                         )
+
+
+
+        
+
+if __name__ == "__main__":
+    main()
+#input_file = "/Users/brodrick/Downloads/emit_emulator_v1.hdf5"
+##out_file = "/Users/brodrick/Downloads/emit_emulator_v1_conv01.hdf5"
+#out_file = "/Users/brodrick/Downloads/emit_emulator_v1_conv_EMIT_Wavelengths_20220817_clipped.hdf5"
+#out_file = "/Users/brodrick/repos/kf/convolved/neon_emulator_v1_conv.hdf5"
+#subprocess.call(f"cp {input_file} {out_file}", shell=True)
+
+input_file = "data_202411121/emit_emulator_v2_0.hdf5"
+out_file = "data_202411121/emit_emulator_v2_conv_EMIT_Wavelengths_20220817_clipped.hdf5"
+
+input =  h5py.File(input_file, "r")
+output = h5py.File(out_file, "w")
+
+def copy_groups(name, obj):
+    if isinstance(obj, h5py.Group):
+        output.create_group(name)
+input.visititems(copy_groups)
+
+def copy_attributes(name, obj):
+    if isinstance(obj, h5py.Group) or isinstance(obj, h5py.Dataset):
+        for key, value in obj.attrs.items():
+            output[name].attrs[key] = value
+input.visititems(copy_attributes)
+
+
+wl = input["MISCELLANEOUS"]["Wavelengths"][:]
+X = input["sample_space"]["sample space"][:,:]
+Y_all = input["mod_output/modtran output"][:,:,:]
+
+
+output_wl = np.genfromtxt('wl/EMIT_Wavelengths_20220817.txt')[:,1:][::-1,:]*1000
+subset = np.where((output_wl[:,0] >= wl[0]) & (output_wl[:,0] <= wl[-1]))[0]
+output_wl = output_wl[subset,:]
+subset = np.where((output_wl[:,0] >= 380) & (output_wl[:,0] <= 2493))[0]
+output_wl = output_wl[subset,:]
+#output_wl = np.genfromtxt('wl/neon_wl.txt')[:,1:]
+
+
+print('prepping')
+for key, value in input["sample_space"].items():
+    output.create_dataset(f"sample_space/{key}", data=value)
+for key, value in input["MISCELLANEOUS"].items():
+    output.create_dataset(f"MISCELLANEOUS/{key}", data=value)
+
+# overwrite wavelengths
+del output["MISCELLANEOUS/Wavelengths"]
+output["MISCELLANEOUS/Wavelengths"] = output_wl[:,0]
+
+yn = input['mod_output'].attrs['Products'].tolist()
+del input
+print('convolving')
+##res = resample(wl, np.arange(wl[0], wl[-1], 0.1), 0.1*np.ones(len(np.arange(wl[0], wl[-1], 0.1))))
+##res = resample(wl, np.arange(wl[0], wl[-1], 5.0), 5.0*np.ones(len(np.arange(wl[0], wl[-1], 5.0))))
+print(output_wl[:,0].shape)
+print(Y_all.shape)
+print(wl.shape)
+res = resample(wl, output_wl[:,0], output_wl[:,1])
+
+yn_out = []
+Y_out = []
+yn_out.append('path_radiance')
+Y_out.append(res.process_data(Y_all[:,yn.index('path_radiance'),:], Y_all.shape[0]))
+
+#yn_out.append('t_down_dir_t_up_dir')
+yn_out.append('bi-direct')
+Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dir'),:]*\
+                              Y_all[:,yn.index('t_up_dir'),:]*\
+                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
+
+#yn_out.append('t_down_dif_t_up_dir')
+yn_out.append('hemi-direct')
+Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dif'),:]*\
+                              Y_all[:,yn.index('t_up_dir'),:]*\
+                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
+
+#yn_out.append('t_down_dir_t_up_dif')
+yn_out.append('direct-hemi')
+Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dir'),:]*\
+                              Y_all[:,yn.index('t_up_dif'),:]*\
+                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
+
+#yn_out.append('t_down_dif_t_up_dif')
+yn_out.append('bi-hemi')
+Y_out.append(res.process_data(Y_all[:,yn.index('t_down_dif'),:]*\
+                              Y_all[:,yn.index('t_up_dif'),:]*\
+                              Y_all[:,yn.index('ToA_irrad'),:], Y_all.shape[0]))
+
+yn_out.append('sphalb')
+Y_out.append(res.process_data(Y_all[:,yn.index('sphalb_num'),:]/\
+                              Y_all[:,yn.index('sphalb_denom'),:], Y_all.shape[0]))
+
+Y_out = np.stack(Y_out, axis=1)
+
+
+print('writing')
+output["mod_output/modtran output"] = Y_out
+output['mod_output'].attrs['Products'] = yn_out
+del output
+
+print('checking')
+input = h5py.File(out_file, "r")
+Y_all = input["mod_output/modtran output"][:,:,:]
+print(Y_all.shape)
+del input
+
+
+#Y_out = []
+#for n in range(Y_all.shape[1]):
+#    Y_out.append(res.process_data(Y_all[:,n,:], Y_all.shape[0]))
+#
+#Y_out = np.stack(Y_out, axis=1)
+#
+#del input["mod_output/modtran output"]
+#input["mod_output/modtran output"] = Y_out
+#del input["MISCELLANEOUS/Wavelengths"]
+#input["MISCELLANEOUS/Wavelengths"] = output_wl[:,0]
+#del input
+#input = h5py.File(out_file, "r")
+#Y_all = input["mod_output/modtran output"][:,:,:]
+#print(Y_all.shape)
+
+
+
+
+
+
+
+
+

--- a/plot_munged.py
+++ b/plot_munged.py
@@ -1,0 +1,147 @@
+
+
+
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.gridspec as gridspec
+import os
+import argparse
+from matplotlib.lines import Line2D
+from scipy import interpolate
+import xarray as xr
+
+def d2_subset(data,ranges):
+    a = data.copy()
+    a = a[ranges[0],:]
+    a = a[:,ranges[1]]
+    return a
+
+def load(
+    file: str,
+    **kwargs,
+) -> xr.Dataset:
+
+    ds = xr.open_dataset(file, mode="r", lock=False, **kwargs)
+    dims = ds.drop_dims("wl").dims
+
+    # Create the point dimension
+    ds = ds.stack(point=dims).transpose("point", "wl")
+    ds.load()
+
+    return ds
+
+def main():
+
+    # Parse arguments
+    parser = argparse.ArgumentParser(description="built luts for emulation.")
+    parser.add_argument('input_netcdf', type=str)
+    parser.add_argument('--comparison_netcdf', type=str, default=None)
+    parser.add_argument('--input_netcdf_name', type=str, default=None)
+    parser.add_argument('--comparison_netcdf_name', type=str, default=None)
+    parser.add_argument('--variables', type=str, nargs='+', default=['rhoatm','sphalb','transm_down_dir','transm_down_dif', 'transm_up_dir','transm_up_dif'])
+    parser.add_argument('-fig_dir', type=str, default='figs')
+
+    args = parser.parse_args()
+
+    np.random.seed(13)
+
+    rtm = load(args.input_netcdf)
+    rtm_points = np.vstack([x.data.tolist() for x in rtm.point])
+    if args.comparison_netcdf is not None:
+        rtm_comp = load(args.comparison_netcdf)
+        rtm_comp_points = np.vstack([x.data.tolist() for x in rtm.point])
+        if np.all(rtm_points == rtm_comp_points) is False:
+            print('Points do not match between input and comparison netcdf, terminating')
+            exit()
+
+    for name in list(args.variables):
+        if name not in list(rtm.variables):
+            print(f'Could not find {name} in primary .nc, terminating')
+            exit()
+        if args.comparison_netcdf and name not in list(rtm_comp.variables):
+            print(f'Could not find {name} in secondary .nc, terminating')
+            exit()
+    
+
+
+    point_names = list(rtm.point.to_index().names)
+
+    bad_points = np.zeros(rtm_points.shape[0],dtype=bool)
+    if 'surface_elevation_km' in point_names and 'observer_altitude_km' in point_names:
+        bad_points = rtm_points[:, point_names.index('surface_elevation_km')]  >= rtm_points[:, point_names.index('observer_altitude_km')] -2
+        good_points = np.logical_not(bad_points)
+    bad_ind = np.any(rtm_comp['transm_down_dif'].data[:,:] > 10,axis=1)
+    import ipdb; ipdb.set_trace()
+
+    lims_main = [[0, 1], [0, 0.25], [0, 0.35]]
+    lims_diff = [[0, 0.25], [0, 0.1], [0, 0.1]]
+
+    cmap = plt.get_cmap('coolwarm')
+    for dim in range(len(point_names)):
+
+        fig = plt.figure(figsize=(30, 10))
+        gs = gridspec.GridSpec(ncols=len(args.variables), nrows=2,wspace=0.2, hspace=0.2)
+        plt.suptitle(point_names[dim])
+
+        #slice = np.take(points,np.arange(0,points.shape[0]),axis=dim)
+        slice = rtm_points[:,dim]
+        un_vals = np.unique(slice)
+
+        for key_ind, key in enumerate(args.variables):
+            ax = fig.add_subplot(gs[0,key_ind])
+            plt.title(f'{args.input_netcdf_name}: {args.variables[key_ind]}')
+
+            leg_lines = []
+            leg_names = []
+            for _val, val in enumerate(un_vals):
+                rtm_slice = np.nanmean(rtm[key].data[np.logical_and(slice == val, good_points), :], axis=0)
+                plt.plot(rtm.wl, rtm_slice, c=cmap(float(_val)/len(un_vals)), linewidth=1)
+
+                leg_lines.append(Line2D([0], [0], color=cmap(float(_val)/len(un_vals)), lw=2))
+                leg_names.append(str(round(val,2)))
+
+            #plt.ylim(lims_main[key_ind])
+            plt.xlabel('Wavelength [nm]')
+
+            if key_ind == 1:
+
+                if point_names[dim] == 'H2OSTR':
+                    pn = 'Water Vapor\n[g cm$^{-1}$]'
+                elif point_names[dim] == 'AOT550' or point_names[dim] == 'AERFRAC_2':
+                    pn = 'Aerosol Optical\nDepth'
+                elif point_names[dim] == 'observer_altitude_km':
+                    pn = 'Observer\nAltitude [km]'
+                elif point_names[dim] == 'surface_elevation_km':
+                    pn = 'Surface\nElevation [km]'
+                elif point_names[dim] == 'solar_zenith':
+                    pn = 'Solar\nZenith Angle [deg]'
+                else:
+                    pn = point_names[dim]
+
+                plt.legend(leg_lines, leg_names, title=pn)
+
+                #pointstr = '{}: {} - {}'.format(point_names[dim], un_vals[0],un_vals[-1])
+                #plt.text(50, 0.9 * (lims_main[key_ind][1] - lims_main[key_ind][0]) + lims_main[key_ind][0], pointstr,
+                #         verticalalignment='top')
+            #elif key_ind == 2 and args.comparison_netcdf:
+            #     
+            #    leg_lines = [Line2D([0], [0], color='black', lw=2),
+            #                 Line2D([0], [0], color='black', lw=2, ls='--')
+            #                ]
+            #    plt.legend(leg_lines, [args.input_netcdf_name, args.comparison_netcdf_name], title='RTM')
+
+        if args.comparison_netcdf:
+            for key_ind, key in enumerate(args.variables):
+                ax = fig.add_subplot(gs[1,key_ind])
+                plt.title(f'{args.comparison_netcdf_name}: {key}')
+                for _val, val in enumerate(un_vals):
+                    rtm_comp_slice = np.nanmean(rtm_comp[key].data[np.logical_and(slice == val, good_points), :], axis=0)
+                    plt.plot(rtm_comp.wl, rtm_comp_slice, c=cmap(float(_val)/len(un_vals)), linewidth=1, linestyle='--')
+
+        plt.savefig(f'{args.fig_dir}/dim_{point_names[dim]}.png', dpi=200, bbox_inches='tight')
+        plt.clf()
+
+
+if __name__ == '__main__':
+    main()

--- a/train_combined_emulator.py
+++ b/train_combined_emulator.py
@@ -250,6 +250,15 @@ def main():
 
     print(modtran_results.shape)
 
+    #fig = plt.figure(figsize=(20,5))
+    #gs = gridspec.GridSpec(ncols=1, nrows=2, wspace=0.3, hspace=0.4)
+    #ax = fig.add_subplot(gs[0, 0])
+    #plt.plot(np.mean(modtran_results,axis=0))
+    #ax = fig.add_subplot(gs[1, 0])
+    #plt.plot(np.mean(sixs_results,axis=0))
+    #plt.savefig('figs/h2o_comp/inputs.png',dpi=200,bbox_inches='tight')
+    #exit()
+
 
 
     if args.holdout_dim == -1:
@@ -306,14 +315,15 @@ def main():
     monitor='val_loss'
         
     es = keras.callbacks.EarlyStopping(monitor=monitor, mode='min', verbose=1, patience=20, restore_best_weights=True)
-    model = nn_model_ind(train_sixs.shape, train_modtran.shape, len(keys))
+    #model = nn_model_ind(train_sixs.shape, train_modtran.shape, len(keys))
+    model = nn_model(train_sixs.shape, train_modtran.shape)
     print(model.summary())
 
 
     simple_response_scaler = np.ones(train_modtran.shape[1])*100
     train_modtran *= simple_response_scaler
     #import ipdb; ipdb.set_trace()
-    model.fit(train_sixs[train,:], train_modtran[train,:], batch_size=10, epochs=400,
+    model.fit(train_sixs[train,:], train_modtran[train,:], batch_size=1000, epochs=400,
               validation_data=(train_sixs[test,:], train_modtran[test,:]),callbacks=[es])
     train_modtran /= simple_response_scaler
 


### PR DESCRIPTION
Here are the updates for the build_lut scripts with all of the hooks working with Isofit 3. It may need another pair of eyes to validate that the configs generated have all of the necessary components.

This also includes a new flag in the cli to make the grid via a sobel sequence. I tried the match the Julia code from the Sobel branch.  The regular and Sobel grids used are still hard coded into the python script. The regular grid is the same as what is on the original branch. The Sobel grid is smaller (from my testing)

In the Sobel grid generation, I've made it possible to generate different lengths of lut elements. This should be pretty self-explanatory in the code.

So far I haven't done too much rigorous testing. 
- I have only run locally to confirm that the correct number of files are generated. I was having some issues this weekend where only one worker was saving the files. I just re-ran today and couldn't replicate this issue. 
- It needs to be run on the cluster to confirm.
- I also haven't run the generated config files through modtran/6s to confirm that they work properly. 

This will also need a PR on Isofit to go through to run properly. I'll attempt to link the two.